### PR TITLE
[Sikkerhet] Oppdaterer med ny catalog-info.yaml og engelske filnavn

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-/.sikkerhet/ @toreJohnsen
+/.security/ @toreJohnsen

--- a/.security/description.yaml
+++ b/.security/description.yaml
@@ -1,4 +1,3 @@
-version: 3.0
 organization: IT
 product: 
 repo_types: [Deprecated]

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -8,29 +8,3 @@ spec:
   type: "experiment"
   lifecycle: "deprecated"
   owner: "standardisering"
----
-apiVersion: "backstage.io/v1alpha1"
-kind: "Group"
-metadata:
-  name: "security_champion_Standardisering"
-  title: "Security Champion Standardisering"
-spec:
-  type: "security_champion"
-  parent: "it_security_champions"
-  members:
-  - "toreJohnsen"
-  children:
-  - "resource:Standardisering"
----
-apiVersion: "backstage.io/v1alpha1"
-kind: "Resource"
-metadata:
-  name: "Standardisering"
-  links:
-  - url: "https://github.com/kartverket/Standardisering"
-    title: "Standardisering på GitHub"
-spec:
-  type: "repo"
-  owner: "security_champion_Standardisering"
-  dependencyOf:
-  - "component:Standardisering"


### PR DESCRIPTION
Denne PRen oppdaterer `catalog-info.yaml` for å gi entiteter til Backstage. Vi fjerner nå resource og sec. champ hierarkiet. Videre dropper vi å ha versionsnummer i description.yaml